### PR TITLE
新規ユーザー登録ページ

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
+import Link from 'next/link';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -32,6 +33,13 @@ export default function LoginPage() {
           className="w-full border px-3 py-2" required />
         <button type="submit" className="w-full bg-blue-500 text-white py-2">ログイン</button>
       </form>
+
+      <div className="mt-4 text-center">
+        <span>アカウントをお持ちでない方は </span>
+        <Link href="/register" className="text-blue-500 hover:underline">
+          ユーザー登録はこちら
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { api } from '@/lib/api';
+import { useUser } from '@/lib/auth';
+import { getCsrfToken } from '@/lib/csrf';
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const { user } = useUser();
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirmation, setPasswordConfirmation] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (user) {
+      router.replace('/todos'); // 既にログインしていればリダイレクト
+    }
+  }, [user]);
+
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    if (password !== passwordConfirmation) {
+      setError('パスワードが一致しません');
+      return;
+    }
+
+    try {
+      await getCsrfToken();
+      await api.post('/register', { name, email, password, password_confirmation: passwordConfirmation });
+      await api.post('/login', { email, password });
+      await getCsrfToken();
+      window.location.href = '/todos'; // 登録成功でリダイレクト（リロード付きで確実に）
+    } catch (err: any) {
+      console.error(err.response?.data);
+      setError('登録に失敗しました');
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto mt-20 p-6 border rounded-xl">
+      <h1 className="text-2xl font-bold mb-4">ユーザー登録</h1>
+
+      {error && <div className="mb-4 text-red-500">{error}</div>}
+
+      <form onSubmit={handleRegister} className="space-y-4">
+        <div>
+          <label className="block mb-1">名前</label>
+          <input
+            className="w-full border px-3 py-2"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block mb-1">メールアドレス</label>
+          <input
+            type="email"
+            className="w-full border px-3 py-2"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block mb-1">パスワード</label>
+          <input
+            type="password"
+            className="w-full border px-3 py-2"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+
+        <div>
+          <label className="block mb-1">パスワード（確認）</label>
+          <input
+            type="password"
+            className="w-full border px-3 py-2"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            required
+          />
+        </div>
+
+        <button className="w-full bg-blue-500 text-white py-2" type="submit">
+          登録
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -15,6 +15,7 @@ export default function RegisterPage() {
   const [password, setPassword] = useState('');
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [error, setError] = useState('');
+  const [validationErrors, setValidationErrors] = useState<Record<string, string[]>>({});
 
   useEffect(() => {
     if (user) {
@@ -38,8 +39,11 @@ export default function RegisterPage() {
       await getCsrfToken();
       window.location.href = '/todos'; // 登録成功でリダイレクト（リロード付きで確実に）
     } catch (err: any) {
-      console.error(err.response?.data);
-      setError('登録に失敗しました');
+      if (err.response?.status === 422) {
+        setValidationErrors(err.response.data.errors);
+      } else {
+        setError('登録に失敗しました');
+      }
     }
   };
 
@@ -58,6 +62,13 @@ export default function RegisterPage() {
             onChange={(e) => setName(e.target.value)}
             required
           />
+          {validationErrors.name && (
+            <ul className="text-red-500 text-sm mt-1 space-y-1">
+              {validationErrors.name.map((message, index) => (
+                <li key={index}>{message}</li>
+              ))}
+            </ul>
+          )}
         </div>
 
         <div>
@@ -69,6 +80,13 @@ export default function RegisterPage() {
             onChange={(e) => setEmail(e.target.value)}
             required
           />
+          {validationErrors.email && (
+            <ul className="text-red-500 text-sm mt-1 space-y-1">
+              {validationErrors.email.map((message, index) => (
+                <li key={index}>{message}</li>
+              ))}
+            </ul>
+          )}
         </div>
 
         <div>
@@ -80,6 +98,13 @@ export default function RegisterPage() {
             onChange={(e) => setPassword(e.target.value)}
             required
           />
+          {validationErrors.password && (
+            <ul className="text-red-500 text-sm mt-1 space-y-1">
+              {validationErrors.password.map((message, index) => (
+                <li key={index}>{message}</li>
+              ))}
+            </ul>
+          )}
         </div>
 
         <div>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -55,8 +55,9 @@ export default function RegisterPage() {
 
       <form onSubmit={handleRegister} className="space-y-4">
         <div>
-          <label className="block mb-1">名前</label>
+          <label htmlFor='name' className="block mb-1">名前</label>
           <input
+            id='name'
             className="w-full border px-3 py-2"
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -72,9 +73,10 @@ export default function RegisterPage() {
         </div>
 
         <div>
-          <label className="block mb-1">メールアドレス</label>
+          <label htmlFor='email' className="block mb-1">メールアドレス</label>
           <input
             type="email"
+            id='email'
             className="w-full border px-3 py-2"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -90,9 +92,10 @@ export default function RegisterPage() {
         </div>
 
         <div>
-          <label className="block mb-1">パスワード</label>
+          <label htmlFor='password' className="block mb-1">パスワード</label>
           <input
             type="password"
+            id='password'
             className="w-full border px-3 py-2"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -108,9 +111,10 @@ export default function RegisterPage() {
         </div>
 
         <div>
-          <label className="block mb-1">パスワード（確認）</label>
+          <label htmlFor='passwordConfirmation' className="block mb-1">パスワード（確認）</label>
           <input
             type="password"
+            id='passwordConfirmation'
             className="w-full border px-3 py-2"
             value={passwordConfirmation}
             onChange={(e) => setPasswordConfirmation(e.target.value)}


### PR DESCRIPTION
`/register`ページを作成しました。

`/register`処理後`/login`して`/sanctum/csrf-cookie`を取得し`window.location.href='/todos'`の流れで安定させます。
Laravel Sanctumは登録時に自動ログインするが、クッキーがクライアント側で即座に安定しないことがある。
明示的にログイン処理を追加すると、クライアント → サーバ間で認証状態が確実に同期される。
その後の CSRF トークン取得で 最新のトークンとクッキーが完全に揃う。
router.push だとクッキーの確定が間に合わないことがある。
window.location.href だと完全にページをリロードするので、クッキー・CSRF が必ず反映される。
Laravel Sanctum × Next.js のセッション確立には「クッキーの反映タイミング」が非常に重要。
明示的なログイン処理 → CSRF 再取得 → リロード付き遷移
この流れにすると、一気に安定します。

バックエンドのバリデーションエラーメッセージを表示しました。