### PR TITLE
期限日の追加

### DIFF
--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
 import { useUser } from '@/lib/auth';
 import { logout } from '@/lib/auth';
+import axios from 'axios';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
@@ -71,8 +72,8 @@ export default function TodosPage() {
       setNewTask('');
       setDueDate('');
       fetchTasks();
-    } catch (error: any) {
-      if (error.response && error.response.status === 422) {
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 422) {
         const errors = error.response.data.errors as Record<string, string[]>;
         const messages = Object.values(errors).flat();
         setErrorMessages(messages);
@@ -136,8 +137,8 @@ export default function TodosPage() {
       });
       cancelEdit();
       fetchTasks();
-    } catch (error: any) {
-      if (error.response && error.response.status === 422) {
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 422) {
         const errors = error.response.data.errors as Record<string, string[]>;
         const messages = Object.values(errors).flat();
         setErrorMessages(messages);

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -69,6 +69,7 @@ export default function TodosPage() {
         due_date: dueDate ? dayjs(dueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
       });
       setNewTask('');
+      setDueDate('');
       fetchTasks();
     } catch (error: any) {
       if (error.response && error.response.status === 422) {

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -131,8 +131,14 @@ export default function TodosPage() {
       });
       cancelEdit();
       fetchTasks();
-    } catch (error) {
-      console.error(error);
+    } catch (error: any) {
+      if (error.response && error.response.status === 422) {
+        const errors = error.response.data.errors as Record<string, string[]>;
+        const messages = Object.values(errors).flat();
+        setErrorMessages(messages);
+      } else {
+        console.error('Unexpected error:', error);
+      }
     } finally {
       setIsSaving(false);
     }

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
 import { useUser } from '@/lib/auth';
 import { logout } from '@/lib/auth';
+import dayjs from 'dayjs';
 
 type Task = {
   id: number;
@@ -172,9 +173,9 @@ export default function TodosPage() {
                   onChange={(e) => setEditTitle(e.target.value)}
                 />
                 <input
-                  type="date"
+                  type="datetime-local"
                   className="border p-2"
-                  value={editDueDate}
+                  value={editDueDate ? dayjs(editDueDate).format('YYYY-MM-DDTHH:mm') : ''}
                   onChange={(e) => setEditDueDate(e.target.value)}
                 />
                 <div className="flex space-x-2">
@@ -191,7 +192,7 @@ export default function TodosPage() {
                     {task.title}
                   </span>
                   {task.due_date && (
-                    <div className="text-sm text-gray-500">期限: {task.due_date}</div>
+                    <div className="text-sm text-gray-500">期限: {dayjs(task.due_date).format('YYYY-MM-DD HH:mm')}</div>
                   )}
                 </div>
                 <div className="flex space-x-2">

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -132,7 +132,7 @@ export default function TodosPage() {
       await getCsrfToken();
       await api.put(`/api/tasks/${id}`, {
         title: editTitle,
-        due_date: editDueDate,
+        due_date: editDueDate ? dayjs(editDueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
       });
       cancelEdit();
       fetchTasks();

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -7,6 +7,10 @@ import { getCsrfToken } from '@/lib/csrf';
 import { useUser } from '@/lib/auth';
 import { logout } from '@/lib/auth';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 type Task = {
   id: number;
@@ -62,7 +66,7 @@ export default function TodosPage() {
       await getCsrfToken();
       await api.post('/api/tasks', {
         title: newTask,
-        due_date: dueDate ? dayjs(dueDate).toISOString() : null,
+        due_date: dueDate ? dayjs(dueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
       });
       setNewTask('');
       fetchTasks();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.9.0",
+        "dayjs": "^1.11.13",
         "js-cookie": "^3.0.5",
         "next": "15.3.3",
         "react": "^19.0.0",
@@ -2467,6 +2468,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.9.0",
+    "dayjs": "^1.11.13",
     "js-cookie": "^3.0.5",
     "next": "15.3.3",
     "react": "^19.0.0",


### PR DESCRIPTION
タスクに期限日を設定できるようにしました。
タスク登録時に期限日を任意で登録できます。
過去の日付は登録できません。
バックエンドからのバリデーションエラーメッセージを表示します。
タスクの編集でタスク名と期限日を設定できます。
インライン編集を採用しました。
Day.jsパッケージを導入してdue_dateをdatetime型にしました。
バックエンドに送る日付の形はYYYY-MM-DDTHH:mmになっています。
ボタン連打でエラーになるのを防止しています。