### PR TITLE
リファクタリング_todos/pageをコンポーネントに分割する

### DIFF
--- a/app/todos/components/EditTaskForm.tsx
+++ b/app/todos/components/EditTaskForm.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import React, { useState } from 'react';
+import { api } from '@/lib/api';
+import { getCsrfToken } from '@/lib/csrf';
+import axios from 'axios';
+import dayjs from 'dayjs';
+
+type Task = {
+  id: number;
+  title: string;
+  is_completed: boolean;
+  due_date: string | null;
+};
+
+type EditTaskFormProps = {
+  task: Task;
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>;
+  setErrorMessages: React.Dispatch<React.SetStateAction<string[]>>;
+  setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+export default function EditTaskForm({ task, setTasks, setErrorMessages, setIsEditing }: EditTaskFormProps) {
+  const [editTitle, setEditTitle] = useState(task.title);
+  const [editDueDate, setEditDueDate] = useState(task.due_date || '');
+
+  const [isSaving, setIsSaving] = useState(false);
+
+  const saveTask = async (id: number) => {
+    if (isSaving) return; // 二重送信防止
+    setIsSaving(true);
+
+    try {
+      await getCsrfToken();
+      await api.put(`/api/tasks/${id}`, {
+        title: editTitle,
+        due_date: editDueDate ? dayjs(editDueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
+      });
+
+      setTasks(tasks => {
+        return tasks.map(t => t.id === task.id ? {...t, title: editTitle, due_date: editDueDate} : t);
+      });
+      setIsEditing(false);
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 422) {
+        const errors = error.response.data.errors as Record<string, string[]>;
+        const messages = Object.values(errors).flat();
+        setErrorMessages(messages);
+      } else {
+        console.error('Unexpected error:', error);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const cancelEdit = () => {
+    setIsEditing(false);
+    setEditTitle(task.title);
+    setEditDueDate(task.due_date || '');
+  };
+
+  return (
+    <div className="flex flex-col space-y-2">
+      <input
+        className="border p-2"
+        value={editTitle}
+        onChange={(e) => setEditTitle(e.target.value)}
+      />
+      <input
+        type="datetime-local"
+        className="border p-2"
+        value={editDueDate ? dayjs(editDueDate).format('YYYY-MM-DDTHH:mm') : ''}
+        onChange={(e) => setEditDueDate(e.target.value)}
+      />
+      <div className="flex space-x-2">
+        <button onClick={() => saveTask(task.id)} disabled={isSaving}>
+          {isSaving ? '保存中...' : '保存'}
+        </button>
+        <button onClick={cancelEdit}>キャンセル</button>
+      </div>
+    </div>
+  );
+};

--- a/app/todos/components/EditTaskForm.tsx
+++ b/app/todos/components/EditTaskForm.tsx
@@ -3,8 +3,8 @@
 import React, { useState } from 'react';
 import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
+import { dayjs } from '@/lib/dayjs';
 import axios from 'axios';
-import dayjs from 'dayjs';
 
 type Task = {
   id: number;
@@ -34,7 +34,7 @@ export default function EditTaskForm({ task, setTasks, setErrorMessages, setIsEd
       await getCsrfToken();
       await api.put(`/api/tasks/${id}`, {
         title: editTitle,
-        due_date: editDueDate ? dayjs(editDueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
+        due_date: editDueDate ? dayjs(editDueDate).format('YYYY-MM-DDTHH:mm:ssZ') : null,
       });
 
       setTasks(tasks => {

--- a/app/todos/components/LogoutButton.tsx
+++ b/app/todos/components/LogoutButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+type LogoutButtonProps = {
+  onLogout: () => Promise<void>;
+  loggingOut: boolean;
+};
+
+export default function LogoutButton({onLogout, loggingOut}: LogoutButtonProps) {
+  return (
+    <button
+      className="text-sm text-gray-500 hover:underline disabled:opacity-50"
+      onClick={onLogout}
+      disabled={loggingOut}
+    >
+      {loggingOut ? 'ログアウト中…' : 'ログアウト'}
+    </button>
+  );
+};

--- a/app/todos/components/TaskForm.tsx
+++ b/app/todos/components/TaskForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import dayjs from 'dayjs';
 import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
+import { dayjs } from '@/lib/dayjs';
 import axios from 'axios';
 
 type TaskFormProps = {
@@ -26,7 +26,7 @@ export default function TaskForm({ onAdd, setErrorMessages }: TaskFormProps) {
       await getCsrfToken();
       await api.post('/api/tasks', {
         title: newTask,
-        due_date: dueDate ? dayjs(dueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
+        due_date: dueDate ? dayjs(dueDate).format('YYYY-MM-DDTHH:mm:ssZ') : null,
       });
       setNewTask('');
       setDueDate('');

--- a/app/todos/components/TaskForm.tsx
+++ b/app/todos/components/TaskForm.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import dayjs from 'dayjs';
+import { api } from '@/lib/api';
+import { getCsrfToken } from '@/lib/csrf';
+import axios from 'axios';
+
+type TaskFormProps = {
+  onAdd: () => void;  // タスク追加後に親へ通知
+  setErrorMessages: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+export default function TaskForm({ onAdd, setErrorMessages }: TaskFormProps) {
+  const [newTask, setNewTask] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [isPosting, setIsPosting] = useState(false);
+
+  const addTask = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isPosting || !newTask.trim()) return;
+    if (dueDate && dayjs(dueDate).isBefore(dayjs())) {
+      alert('期限は現在より未来の日時を指定してください。');
+      return;
+    }
+    setIsPosting(true);
+    try {
+      await getCsrfToken();
+      await api.post('/api/tasks', {
+        title: newTask,
+        due_date: dueDate ? dayjs(dueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
+      });
+      setNewTask('');
+      setDueDate('');
+      setErrorMessages([]);
+      onAdd();  // 親に通知
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 422) {
+        const errors = error.response.data.errors as Record<string, string[]>;
+        const messages = Object.values(errors).flat();
+        setErrorMessages(messages);
+      } else {
+        console.error('Unexpected error:', error);
+      }
+    } finally {
+      setIsPosting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={addTask} className="flex mb-4 space-x-2">
+      <input
+        className="flex-grow border px-3 py-2"
+        placeholder="新しいタスクを追加"
+        value={newTask}
+        onChange={(e) => setNewTask(e.target.value)}
+      />
+      <input
+        type="datetime-local"
+        className="flex-grow px-3 py-2"
+        value={dueDate}
+        onChange={(e) => setDueDate(e.target.value)}
+        min={dayjs().format('YYYY-MM-DDTHH:mm')}  // 過去禁止
+      />
+      <button type="submit" className="bg-blue-500 text-white px-4 py-2" disabled={isPosting}>
+        追加
+      </button>
+    </form>
+  );
+};

--- a/app/todos/components/TaskItem.tsx
+++ b/app/todos/components/TaskItem.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React, { useState } from 'react';
+import { api } from '@/lib/api';
+import { getCsrfToken } from '@/lib/csrf';
+import axios from 'axios';
+import dayjs from 'dayjs';
+
+type Task = {
+  id: number;
+  title: string;
+  is_completed: boolean;
+  due_date: string | null;
+};
+
+type TaskItemProps = {
+  task: Task;
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>;
+  setErrorMessages: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+export default function TaskItem({ task, setTasks, setErrorMessages }: TaskItemProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(task.title);
+  const [editDueDate, setEditDueDate] = useState(task.due_date || '');
+
+  const [isToggling, setIsToggling] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const [isSaving, setIsSaving] = useState(false);
+
+  const toggleTask = async (task: Task) => {
+    if (isToggling) return;
+    setIsToggling(true);
+    try {
+      await getCsrfToken();
+      await api.put(`/api/tasks/${task.id}`, { is_completed: !task.is_completed });
+
+      setTasks(tasks => {
+        return tasks.map(t => t.id === task.id ? {...t, is_completed: !t.is_completed} : t);
+      });
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setIsToggling(false);
+    }
+  };
+
+  const deleteTask = async (id: number) => {
+    if (isDeleting) return;
+    setIsDeleting(true);
+    try {
+      await getCsrfToken();
+      await api.delete(`/api/tasks/${id}`);
+
+      setTasks(tasks => {
+        return tasks.filter(t => t.id !== task.id);
+      });
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const saveTask = async (id: number) => {
+    if (isSaving) return; // 二重送信防止
+    setIsSaving(true);
+
+    try {
+      await getCsrfToken();
+      await api.put(`/api/tasks/${id}`, {
+        title: editTitle,
+        due_date: editDueDate ? dayjs(editDueDate).tz('Asia/Tokyo').format('YYYY-MM-DDTHH:mm:ssZ') : null,
+      });
+
+      setTasks(tasks => {
+        return tasks.map(t => t.id === task.id ? {...t, title: editTitle, due_date: editDueDate} : t);
+      });
+      setIsEditing(false);
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error) && error.response && error.response.status === 422) {
+        const errors = error.response.data.errors as Record<string, string[]>;
+        const messages = Object.values(errors).flat();
+        setErrorMessages(messages);
+      } else {
+        console.error('Unexpected error:', error);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const cancelEdit = () => {
+    setIsEditing(false);
+    setEditTitle(task.title);
+    setEditDueDate(task.due_date || '');
+  };
+
+  return (
+    <li key={task.id} className="flex flex-col border p-3">
+      {isEditing ? (
+        <div className="flex flex-col space-y-2">
+          <input
+            className="border p-2"
+            value={editTitle}
+            onChange={(e) => setEditTitle(e.target.value)}
+          />
+          <input
+            type="datetime-local"
+            className="border p-2"
+            value={editDueDate ? dayjs(editDueDate).format('YYYY-MM-DDTHH:mm') : ''}
+            onChange={(e) => setEditDueDate(e.target.value)}
+          />
+          <div className="flex space-x-2">
+            <button onClick={() => saveTask(task.id)} disabled={isSaving}>
+              {isSaving ? '保存中...' : '保存'}
+            </button>
+            <button onClick={cancelEdit}>キャンセル</button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex justify-between items-center">
+          <div onClick={() => setIsEditing(true)} className="cursor-pointer">
+            <span className={task.is_completed ? 'line-through text-gray-500' : ''}>
+              {task.title}
+            </span>
+            {task.due_date && (
+              <div className="text-sm text-gray-500">
+                期限: {dayjs(task.due_date).format('YYYY-MM-DD HH:mm')}
+              </div>
+            )}
+          </div>
+          <div className="flex space-x-2">
+            <button onClick={() => toggleTask(task)} disabled={isToggling}>完了</button>
+            <button onClick={() => deleteTask(task.id)} disabled={isDeleting}>削除</button>
+          </div>
+        </div>
+      )}
+    </li>
+  );
+};

--- a/app/todos/components/TaskItem.tsx
+++ b/app/todos/components/TaskItem.tsx
@@ -3,8 +3,8 @@
 import React, { useState } from 'react';
 import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
+import { dayjs } from '@/lib/dayjs';
 import EditTaskForm from './EditTaskForm';
-import dayjs from 'dayjs';
 
 type Task = {
   id: number;

--- a/app/todos/components/TaskList.tsx
+++ b/app/todos/components/TaskList.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import TaskItem from './TaskItem';
+
+type Task = {
+  id: number;
+  title: string;
+  is_completed: boolean;
+  due_date: string | null;
+};
+
+type TaskListProps = {
+  tasks: Task[];
+  setTasks: React.Dispatch<React.SetStateAction<Task[]>>;
+  setErrorMessages: React.Dispatch<React.SetStateAction<string[]>>;
+};
+
+export default function TaskList({ tasks, setTasks, setErrorMessages }: TaskListProps) {
+  return (
+    <ul className="space-y-2">
+      {tasks.map((task) => (
+        <TaskItem
+          key={task.id}
+          task={task}
+          setTasks={setTasks}
+          setErrorMessages={setErrorMessages}
+        />
+      ))}
+    </ul>
+  );
+};

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -6,6 +6,7 @@ import { api } from '@/lib/api';
 import { getCsrfToken } from '@/lib/csrf';
 import { useUser } from '@/lib/auth';
 import { logout } from '@/lib/auth';
+import LogoutButton from './components/LogoutButton';
 import axios from 'axios';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -170,13 +171,7 @@ export default function TodosPage() {
     <div className="max-w-lg mx-auto p-6">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">タスクリスト</h1>
-        <button
-          className="text-sm text-gray-500 hover:underline disabled:opacity-50"
-          onClick={handleLogout}
-          disabled={loggingOut}
-        >
-          {loggingOut ? 'ログアウト中…' : 'ログアウト'}
-        </button>
+        <LogoutButton onLogout={handleLogout} loggingOut={loggingOut} />
       </div>
 
       <form onSubmit={addTask} className="flex mb-4 space-x-2">

--- a/app/todos/page.tsx
+++ b/app/todos/page.tsx
@@ -3,16 +3,10 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { api } from '@/lib/api';
-import { useUser } from '@/lib/auth';
-import { logout } from '@/lib/auth';
+import { useUser, logout } from '@/lib/auth';
 import LogoutButton from './components/LogoutButton';
 import TaskForm from './components/TaskForm';
 import TaskList from './components/TaskList';
-import dayjs from 'dayjs';
-import utc from 'dayjs/plugin/utc';
-import timezone from 'dayjs/plugin/timezone';
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 type Task = {
   id: number;

--- a/lib/dayjs.ts
+++ b/lib/dayjs.ts
@@ -1,0 +1,9 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.tz.setDefault('Asia/Tokyo');
+
+export { dayjs };


### PR DESCRIPTION
一続きだったtodos/pageをコンポーネントに分割して見通しをよくしました。
todos/components/以下に5つのファイルを作成しました。
LogoutButton: ログアウトボタンの部品化
TaskForm: タスク追加欄の部品化、処理も持ってきている
TaskItem: 1件のタスクの部品化、完了・削除の処理も持ってきている
TaskList: TaskItemを並べてリスト化している。
EditTaskForm: インライン編集部分の部品化、編集中・保存の処理も持ってきている
@/lib/dayjs.ts: day.jsパッケージ関係のimportをまとめたもの、タイムゾーン問題解決も行っている